### PR TITLE
[WWFT-13523] - Incorporate Standard Pixel Ratio <r=mprice> <r=jdilts>

### DIFF
--- a/Pod/Classes/TSMessage.h
+++ b/Pod/Classes/TSMessage.h
@@ -74,18 +74,22 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
 
 /** Shows a notification message
  @param message The title of the notification view
+ @param pixelRatio The standard calculated pixel ratio for 6/+ vertical upscaling
  @param type The notification type (Message, Warning, Error, Success)
  */
 + (void)showNotificationWithTitle:(NSString *)message
+                       pixelRatio:(CGFloat)pixelRatio
                              type:(TSMessageNotificationType)type;
 
 /** Shows a notification message
  @param title The title of the notification view
  @param subtitle The text that is displayed underneath the title
+ @param pixelRatio The standard calculated pixel ratio for 6/+ vertical upscaling
  @param type The notification type (Message, Warning, Error, Success)
  */
 + (void)showNotificationWithTitle:(NSString *)title
                          subtitle:(NSString *)subtitle
+                       pixelRatio:(CGFloat)pixelRatio
                              type:(TSMessageNotificationType)type;
 
 /** Shows a notification message in a specific view controller
@@ -93,11 +97,13 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
  You can use +setDefaultViewController: to set the the default one instead
  @param title The title of the notification view
  @param subtitle The text that is displayed underneath the title
+ @param pixelRatio The standard calculated pixel ratio for 6/+ vertical upscaling
  @param type The notification type (Message, Warning, Error, Success)
  */
 + (void)showNotificationInViewController:(UIViewController *)viewController
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type;
 
 /** Shows a notification message in a specific view controller with a specific duration
@@ -105,12 +111,14 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
  You can use +setDefaultViewController: to set the the default one instead
  @param title The title of the notification view
  @param subtitle The text that is displayed underneath the title
+ @param pixelRatio The standard calculated pixel ratio for 6/+ vertical upscaling
  @param type The notification type (Message, Warning, Error, Success)
  @param duration The duration of the notification being displayed
  */
 + (void)showNotificationInViewController:(UIViewController *)viewController
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration;
 
@@ -119,6 +127,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
  You can use +setDefaultViewController: to set the the default one instead
  @param title The title of the notification view
  @param subtitle The text that is displayed underneath the title
+ @param pixelRatio The standard calculated pixel ratio for 6/+ vertical upscaling
  @param type The notification type (Message, Warning, Error, Success)
  @param duration The duration of the notification being displayed
  @param dismissingEnabled Should the message be dismissed when the user taps/swipes it
@@ -126,6 +135,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
 + (void)showNotificationInViewController:(UIViewController *)viewController
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
                     canBeDismissedByUser:(BOOL)dismissingEnabled;
@@ -137,6 +147,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
  @param title The title of the notification view
  @param subtitle The message that is displayed underneath the title (optional)
  @param image A custom icon image (optional)
+ @param pixelRatio The standard calculated pixel ratio for 6/+ vertical upscaling
  @param type The notification type (Message, Warning, Error, Success)
  @param duration The duration of the notification being displayed
  @param callback The block that should be executed, when the user tapped on the message
@@ -151,6 +162,7 @@ typedef NS_ENUM(NSInteger,TSMessageNotificationDuration) {
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
                                    image:(UIImage *)image
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
                                 callback:(void (^)())callback

--- a/Pod/Classes/TSMessage.m
+++ b/Pod/Classes/TSMessage.m
@@ -44,26 +44,31 @@ __weak static UIViewController *_defaultViewController;
 #pragma mark Public methods for setting up the notification
 
 + (void)showNotificationWithTitle:(NSString *)title
+                       pixelRatio:(CGFloat)pixelRatio
                              type:(TSMessageNotificationType)type
 {
     [self showNotificationWithTitle:title
                            subtitle:nil
+                         pixelRatio:pixelRatio
                                type:type];
 }
 
 + (void)showNotificationWithTitle:(NSString *)title
                          subtitle:(NSString *)subtitle
+                       pixelRatio:(CGFloat)pixelRatio
                              type:(TSMessageNotificationType)type
 {
     [self showNotificationInViewController:[self defaultViewController]
                                      title:title
                                   subtitle:subtitle
+                                pixelRatio:pixelRatio
                                       type:type];
 }
 
 + (void)showNotificationInViewController:(UIViewController *)viewController
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
 {
@@ -71,6 +76,7 @@ __weak static UIViewController *_defaultViewController;
                                      title:title
                                   subtitle:subtitle
                                      image:nil
+                                pixelRatio:pixelRatio
                                       type:type
                                   duration:duration
                                   callback:nil
@@ -85,6 +91,7 @@ __weak static UIViewController *_defaultViewController;
 + (void)showNotificationInViewController:(UIViewController *)viewController
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
                     canBeDismissedByUser:(BOOL)dismissingEnabled
@@ -93,6 +100,7 @@ __weak static UIViewController *_defaultViewController;
                                      title:title
                                   subtitle:subtitle
                                      image:nil
+                                pixelRatio:pixelRatio
                                       type:type
                                   duration:duration
                                   callback:nil
@@ -107,12 +115,14 @@ __weak static UIViewController *_defaultViewController;
 + (void)showNotificationInViewController:(UIViewController *)viewController
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type
 {
     [self showNotificationInViewController:viewController
                                      title:title
                                   subtitle:subtitle
                                      image:nil
+                                pixelRatio:pixelRatio
                                       type:type
                                   duration:TSMessageNotificationDurationAutomatic
                                   callback:nil
@@ -129,6 +139,7 @@ __weak static UIViewController *_defaultViewController;
                                    title:(NSString *)title
                                 subtitle:(NSString *)subtitle
                                    image:(UIImage *)image
+                              pixelRatio:(CGFloat)pixelRatio
                                     type:(TSMessageNotificationType)type
                                 duration:(NSTimeInterval)duration
                                 callback:(void (^)())callback
@@ -143,6 +154,7 @@ __weak static UIViewController *_defaultViewController;
     TSMessageView *v = [[TSMessageView alloc] initWithTitle:title
                                                    subtitle:subtitle
                                                       image:image
+                                                 pixelRatio:pixelRatio
                                                        type:type
                                                    duration:duration
                                            inViewController:viewController

--- a/Pod/Classes/TSMessageView.h
+++ b/Pod/Classes/TSMessageView.h
@@ -50,6 +50,7 @@
  @param title The title of the notification view
  @param subtitle The subtitle of the notification view (optional)
  @param image A custom icon image (optional)
+ @param pixelRatio The standard calculated pixel ratio for 6/+ vertical upscaling
  @param notificationType The type (color) of the notification view
  @param duration The duration this notification should be displayed (optional)
  @param viewController The view controller this message should be displayed in
@@ -63,6 +64,7 @@
 - (id)initWithTitle:(NSString *)title
            subtitle:(NSString *)subtitle
               image:(UIImage *)image
+         pixelRatio:(CGFloat)pixelRatio
                type:(TSMessageNotificationType)notificationType
            duration:(CGFloat)duration
    inViewController:(UIViewController *)viewController

--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -50,6 +50,8 @@ static NSMutableDictionary *_notificationDesign;
 @property (nonatomic, assign) CGFloat textSpaceLeft;
 @property (nonatomic, assign) CGFloat textSpaceRight;
 
+@property (nonatomic, assign) CGFloat pixelRatio;
+
 @property (copy) void (^callback)();
 @property (copy) void (^buttonCallback)();
 @property (copy) void (^dismissalCallback)();
@@ -188,6 +190,7 @@ static NSMutableDictionary *_notificationDesign;
 - (id)initWithTitle:(NSString *)title
            subtitle:(NSString *)subtitle
               image:(UIImage *)image
+         pixelRatio:(CGFloat)pixelRatio
                type:(TSMessageNotificationType)aNotificationType
            duration:(CGFloat)duration
    inViewController:(UIViewController *)viewController
@@ -209,6 +212,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         _duration = duration;
         _viewController = viewController;
         _messagePosition = position;
+        _pixelRatio = pixelRatio;
         self.callback = callback;
         self.buttonCallback = buttonCallback;
         self.dismissalCallback = dismissalCallback;

--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -142,8 +142,8 @@ static NSMutableDictionary *_notificationDesign;
     CGFloat yPadding = (yPaddingNumber ? [yPaddingNumber floatValue] : [self padding]) * self.pixelRatio;
     self.iconImageView.frame = CGRectMake(xPadding,
                                           yPadding,
-                                          image.size.width,
-                                          image.size.height);
+                                          image.size.width * self.pixelRatio,
+                                          image.size.height * self.pixelRatio);
 }
 
 

--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -137,9 +137,9 @@ static NSMutableDictionary *_notificationDesign;
             break;
     }
     NSNumber *xPaddingNumber = [self.designDictionary valueForKey:@"xPadding"];
-    CGFloat xPadding = xPaddingNumber ? [xPaddingNumber floatValue] : [self padding];
+    CGFloat xPadding = (xPaddingNumber ? [xPaddingNumber floatValue] : [self padding]) * self.pixelRatio;
     NSNumber *yPaddingNumber = [self.designDictionary valueForKey:@"yPadding"];
-    CGFloat yPadding = yPaddingNumber ? [yPaddingNumber floatValue] : [self padding];
+    CGFloat yPadding = (yPaddingNumber ? [yPaddingNumber floatValue] : [self padding]) * self.pixelRatio;
     self.iconImageView.frame = CGRectMake(xPadding,
                                           yPadding,
                                           image.size.width,
@@ -253,9 +253,9 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         self.designDictionary = current;
         
         NSNumber *xPaddingNumber = [current valueForKey:@"xPadding"];
-        CGFloat xPadding = xPaddingNumber ? [xPaddingNumber floatValue] : [self padding];
+        CGFloat xPadding = (xPaddingNumber ? [xPaddingNumber floatValue] : [self padding]) * self.pixelRatio;
         NSNumber *yPaddingNumber = [current valueForKey:@"yPadding"];
-        CGFloat yPadding = yPaddingNumber ? [yPaddingNumber floatValue] : [self padding];
+        CGFloat yPadding = (yPaddingNumber ? [yPaddingNumber floatValue] : [self padding]) * self.pixelRatio;
 
         if (!image && [[current valueForKey:@"imageName"] length])
         {
@@ -286,14 +286,14 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         UIColor *fontColor = [UIColor colorFromHexString:[current valueForKey:@"textColor"]];
         
         self.textSpaceLeft = xPadding;
-        if (image) self.textSpaceLeft += image.size.width + xPadding;
+        if (image) self.textSpaceLeft += image.size.width * self.pixelRatio + xPadding;
 
         // Set up title label
         _titleLabel = [[UILabel alloc] init];
         [self.titleLabel setText:title];
         [self.titleLabel setTextColor:fontColor];
         [self.titleLabel setBackgroundColor:[UIColor clearColor]];
-        CGFloat fontSize = [[current valueForKey:@"titleFontSize"] floatValue];
+        CGFloat fontSize = [[current valueForKey:@"titleFontSize"] floatValue] * self.pixelRatio;
         NSString *fontName = [current valueForKey:@"titleFontName"];
         if (fontName != nil) {
             [self.titleLabel setFont:[UIFont fontWithName:fontName size:fontSize]];
@@ -323,7 +323,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             }
             [self.contentLabel setTextColor:contentTextColor];
             [self.contentLabel setBackgroundColor:[UIColor clearColor]];
-            CGFloat fontSize = [[current valueForKey:@"contentFontSize"] floatValue];
+            CGFloat fontSize = [[current valueForKey:@"contentFontSize"] floatValue] * self.pixelRatio;
             NSString *fontName = [current valueForKey:@"contentFontName"];
             if (fontName != nil) {
                 [self.contentLabel setFont:[UIFont fontWithName:fontName size:fontSize]];
@@ -345,8 +345,8 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             _iconImageView = [[UIImageView alloc] initWithImage:image];
             self.iconImageView.frame = CGRectMake(xPadding,
                                                   yPadding,
-                                                  image.size.width,
-                                                  image.size.height);
+                                                  image.size.width * self.pixelRatio,
+                                                  image.size.height * self.pixelRatio);
             [self addSubview:self.iconImageView];
         }
 
@@ -363,7 +363,12 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         UIImage *buttonImage = [UIImage imageNamed:[current valueForKey:@"buttonImageName"]];
         if (buttonImage) {
             [self.button setImage:buttonImage forState:UIControlStateNormal];
-            self.button.frame = CGRectMake(0, 0, buttonImage.size.width, buttonImage.size.height);
+            self.button.frame = CGRectMake(0,
+                                           0,
+                                           buttonImage.size.width * self.pixelRatio,
+                                           buttonImage.size.height * self.pixelRatio);
+            self.button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentFill;
+            self.button.contentVerticalAlignment = UIControlContentVerticalAlignmentFill;
         }
         UIImage *buttonHighlightedImage = [UIImage imageNamed:[current valueForKey:@"buttonImageHighlightedName"]];
         if (buttonHighlightedImage) {
@@ -388,7 +393,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             }
 
             [self.button setTitleColor:buttonTitleTextColor forState:UIControlStateNormal];
-            self.button.titleLabel.font = [UIFont boldSystemFontOfSize:14.0];
+            self.button.titleLabel.font = [UIFont boldSystemFontOfSize:14.0 * self.pixelRatio];
             self.button.titleLabel.shadowOffset = CGSizeMake([[current valueForKey:@"buttonTitleShadowOffsetX"] floatValue],
                                                              [[current valueForKey:@"buttonTitleShadowOffsetY"] floatValue]);
         }
@@ -412,7 +417,7 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
             _borderView = [[UIView alloc] initWithFrame:CGRectMake(0.0,
                                                                    0.0, // will be set later
                                                                    screenWidth,
-                                                                   [[current valueForKey:@"borderHeight"] floatValue])];
+                                                                   [[current valueForKey:@"borderHeight"] floatValue] * self.pixelRatio)];
             self.borderView.backgroundColor = [UIColor colorFromHexString:[current valueForKey:@"borderColor"]];
             self.borderView.autoresizingMask = (UIViewAutoresizingFlexibleWidth);
             [self addSubview:self.borderView];
@@ -473,9 +478,9 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
     CGFloat currentHeight;
     CGFloat screenWidth = self.viewController.view.bounds.size.width;
     NSNumber *xPaddingNumber = [self.designDictionary valueForKey:@"xPadding"];
-    CGFloat xPadding = xPaddingNumber ? [xPaddingNumber floatValue] : [self padding];
+    CGFloat xPadding = (xPaddingNumber ? [xPaddingNumber floatValue] : [self padding]) * self.pixelRatio;
     NSNumber *yPaddingNumber = [self.designDictionary valueForKey:@"yPadding"];
-    CGFloat yPadding = yPaddingNumber ? [yPaddingNumber floatValue] : [self padding];
+    CGFloat yPadding = (yPaddingNumber ? [yPaddingNumber floatValue] : [self padding]) * self.pixelRatio;
 
     self.titleLabel.frame = CGRectMake(self.textSpaceLeft,
                                        yPadding + 4.0f,


### PR DESCRIPTION
# Issue

Currently on iPhone 6/6+ devices inline notifications appear smaller than they did previously. This is due to the fact that when we switched to support native 6/6+ resolution TSMessages related UI were not scaled up using standardPixelRatio. 
# Solution

Expose a pixelRatio argument for TSMessages methods. During layout TSMessages now uses this pixelRatio to scale up all UI appropriately.
# JIRA

https://jira.corp.zynga.com/browse/WWFT-13523
# Testing
- [x] Test on iPhone 5/6+ (iOS 8.4), verify that inline notifications look the same
- [x] Test on iPhone 5/6+ (iOS 9.2), verify that inline notifications look the same
