### PR TITLE
[Bug] Inline notif moves to the bottom on rotation

### DIFF
--- a/Pod/Classes/TSMessageView.m
+++ b/Pod/Classes/TSMessageView.m
@@ -663,7 +663,12 @@ canBeDismissedByUser:(BOOL)dismissingEnabled
         currentHeight += yOffset;
     }
     
-    self.frame = CGRectMake(0.0, self.frame.origin.y, self.frame.size.width, currentHeight);
+    // On orientation change, message remains being presented at the top edge of the view
+    if (self.frame.origin.y > 0) {
+        self.frame = CGRectMake(0.0, 0.0, self.frame.size.width, currentHeight);
+    } else {
+        self.frame = CGRectMake(0.0, self.frame.origin.y, self.frame.size.width, currentHeight);
+    }
     
     // Reposition UI elements
     if (self.button)


### PR DESCRIPTION
**Issue:**
Fixed bug where on rotate on iPad, the already presented inline notification would move to the bottom
- Updates the y-coord to zero if it exceeds 0

**Jira:**
https://jira.corp.zynga.com/browse/WWFIII-9309

**Related PR:**
https://github-ca.corp.zynga.com/wwf2/TheNewWordsWithFriends/pull/17290